### PR TITLE
Adjusted generation prompt for instruction recall

### DIFF
--- a/data/gpt_generation_prompts/5-2_instruction_recall.json
+++ b/data/gpt_generation_prompts/5-2_instruction_recall.json
@@ -1,5 +1,5 @@
 {
-  "content":"Create ten (10) sequential steps to set up an object like a drone, phone, smartwatch, or other smart device for its first use, or other similar scenario, use a fictitious brand.",
-  "question":"Generate five (5) questions, each focusing on recalling a specific step or sequence of steps in the content.",
-  "answer":"Generate the corresponding answer for each question."
+  "content":"Imagine a fictional object or process, it can be magical or technological, but will be dissimilar from anything currently existing. Create ten (10) sequential steps to setup the object or execute the process in the style of an instructional manual.",
+  "question":"Generate five (5) questions, each focusing on recalling a specific step or sequence of steps described in the content",
+  "answer":"Generate the corresponding answer for each question. Consider both the content and the question when crafting the answer."
 }


### PR DESCRIPTION
**Issue:**
- Scenarios for instructions were too based on real life object (drone, phone, smartwatch) so the instructions were fairly generic most of the time
- Some questions then ended up being so broad that the LLM could just hallucinate a response without reference to the LTM (e.g "What should you do before flying the drone for the first time?") which is marked correct because of the how broad the generated answer is and how nonspecifc the expected answer is.

**Fix:**
- Adjusted generation prompt to create a more fantastical object that doesn't have a real world allegory. This makes it less likely to produce a scenario with poor quality questions that can be answered by inherent LLM knowledge.