### PR TITLE
Minimum of a single piece of triva for a distraction segment

### DIFF
--- a/utils/filling_task.py
+++ b/utils/filling_task.py
@@ -50,12 +50,14 @@ def filler_no_response_tokens_trivia(num_tokens: int, max_message_size: int):
     tokens_to_return = min(num_tokens, max_message_size)
     total_tokens = token_len(message)
     messages = [message]
+    at_least_one_trivia = False
 
-    while total_tokens < tokens_to_return:
+    while not at_least_one_trivia or total_tokens < tokens_to_return:
         trivia = random.choice(data)
         trivia_msg = f"Q: {trivia['Question']}, A: {trivia['AnswerValue']}\n"
         total_tokens += token_len(trivia_msg)
         messages.append(trivia_msg)
+        at_least_one_trivia = True
 
     return "".join(messages)
 


### PR DESCRIPTION
**Issue:** 
In the distraction segments, we have a stock introduction which tasks the agent to write some JSON to express the answers to the trivia which is to follow. Sometimes this introduction is the only thing that is given to the agent. This can sometimes confuse the agent which is expecting some trivia. 

**Reason:** We count the number of tokens in this introduction and loop adding statements until the number of tokens in the message is greater than the token need. If the token need was low enough, the addition of triva would be skipped and the agent would just get this introduction,

**Fix:** A flag to add at least one line of trivia to the distraction segment