### PR TITLE
Continuous conversation testing method

### DIFF
--- a/configurations/continuous_test.yml
+++ b/configurations/continuous_test.yml
@@ -1,0 +1,40 @@
+config:
+  debug: True
+  run_name: "ContinuousTests"
+  continuous_conversation: True
+  incompatibilities:
+    - - "names"
+      - "name_list"
+    - - "locations"
+      - "locations_directions"
+
+
+datasets:
+    args:
+      filler_tokens_low: 1000
+      filler_tokens_high: 1000
+      pre_question_filler: 1000
+      dataset_examples: 2
+
+    datasets:
+      - name: "name_list"
+        args:
+          name_changes: 2
+
+      - name: "colours"
+
+      - name: "shopping"
+        args:
+          item_changes: 5
+
+      - name: "trigger_response"
+        args:
+          trigger_activations: 3
+
+      - name: "locations_directions"
+        args:
+          known_locations: 6
+
+      - name: "sallyanne"
+        args:
+          data_location: "data/tomi_data/test.txt"

--- a/dataset_interfaces/gpt_generated.py
+++ b/dataset_interfaces/gpt_generated.py
@@ -78,6 +78,7 @@ class GPTGenerated(DatasetInterface, ABC):
                 number_of_questions=self.count_questions(is_question),
                 is_question=is_question,
                 uses_callback=self.uses_callback,
+                reset_message=self.reset_message,
             )
 
             examples.append(example)

--- a/dataset_interfaces/interface.py
+++ b/dataset_interfaces/interface.py
@@ -99,6 +99,7 @@ class TestExample:
     number_of_questions: int = 0
     finished: bool = False
     _iter: Iterator[TestAction] = None
+    reset_message: str = ""
 
     @property
     def unique_id(self):
@@ -145,6 +146,7 @@ class TestExample:
             evaluation_fn=self.evaluation_fn.__name__,
             is_temporal=self.is_temporal,
             uses_callback=self.uses_callback,
+            reset_message=self.reset_message,
         )
 
     def save(self, run_name: str, exist_ok: bool = False):
@@ -199,6 +201,7 @@ class DatasetInterface(ABC):
     seed: int = 0
     cost_callback: Callable[[float], None] = None
     uses_callback: bool = False
+    reset_message: str = ""
 
     def count_questions(self, is_question):
         return len([x for x in is_question if x])

--- a/datasets/chapterbreak.py
+++ b/datasets/chapterbreak.py
@@ -56,6 +56,7 @@ class ChapterBreakDataset(DatasetInterface):
     )
     split: str = "ao3"  # pg19 / ao3 / all
     page_tokens: int = 1024
+    reset_message: str = "Forget the current chapter and its potential continuations."
 
     def __post_init__(self):
         assert self.split in {"pg19", "ao3", "all"}
@@ -120,6 +121,7 @@ class ChapterBreakDataset(DatasetInterface):
                 evaluation_fn=self.evaluate_correct,
                 is_question=is_question,
                 number_of_questions=1,
+                reset_message=self.reset_message,
             )
             example_list.append(example)
 

--- a/datasets/delayed_recall.py
+++ b/datasets/delayed_recall.py
@@ -12,6 +12,7 @@ class DelayedRecallDataset(GPTGenerated):
         "Give the agent a number of facts about a a fictional world, and then ask 10 questions about these facts."
     )
     generation_file: str = str(DATA_DIR.joinpath("gpt_generation_prompts/1-1_delayed_recall.json"))
+    reset_message: str = "Forget all of the facts given to you about the fictional world before this message."
 
     def evaluate_correct(
         self, questions: List[str], responses: List[str], expected_answers: List[str]

--- a/datasets/instruction_recall.py
+++ b/datasets/instruction_recall.py
@@ -11,6 +11,7 @@ class InstructionRecallDataset(GPTGenerated):
     name: str = "Instruction Recall"
     description: str = "Give the agent a list of instructions, then ask it multiple questions about these instructions"
     generation_file: str = str(DATA_DIR.joinpath("gpt_generation_prompts/5-2_instruction_recall.json"))
+    eset_message: str = "Forget all of the instructions for operating the technology that I have given you up until this message."
 
     def evaluate_correct(
         self, questions: List[str], responses: List[str], expected_answers: List[Any]

--- a/datasets/locations.py
+++ b/datasets/locations.py
@@ -41,6 +41,7 @@ class LocationsDataset(DatasetInterface):
     description: str = "Tell the agents about locations in our hometown, with each's position being described relative to the previous one. Finally the agent is asked the distance and direction from the first mentioned place to the last."
     question: str = "Please calculate the direction and distance starting from {{place}} going directly to {{origin}}. Solve it step by step."
     known_locations: int = 5
+    reset_message = "Forget, or otherwise disregard, all of the locations that I have told you about before this message."
 
     def generate_examples(self, num_examples):
         examples = []
@@ -112,6 +113,7 @@ class LocationsDataset(DatasetInterface):
                 evaluation_fn=self.evaluate_correct,
                 number_of_questions=self.count_questions(is_question),
                 is_question=is_question,
+                reset_message=self.reset_message
             )
 
             examples.append(example)

--- a/datasets/locations.py
+++ b/datasets/locations.py
@@ -41,7 +41,7 @@ class LocationsDataset(DatasetInterface):
     description: str = "Tell the agents about locations in our hometown, with each's position being described relative to the previous one. Finally the agent is asked the distance and direction from the first mentioned place to the last."
     question: str = "Please calculate the direction and distance starting from {{place}} going directly to {{origin}}. Solve it step by step."
     known_locations: int = 5
-    reset_message = "Forget, or otherwise disregard, all of the locations that I have told you about before this message."
+    reset_message: str = "Forget, or otherwise disregard, all of the locations that I have told you about before this message."
 
     def generate_examples(self, num_examples):
         examples = []

--- a/datasets/shopping.py
+++ b/datasets/shopping.py
@@ -158,7 +158,7 @@ class ShoppingDataset(DatasetInterface):
         if num_correct < max_score:
             errors.append(f"{max_score - num_correct} items were not found in the response.")
 
-        num_correct -= penalties
+        num_correct = max(num_correct - penalties, 0)
         if num_correct == max_score:
             reasoning = "All items and quantities match."
         else:

--- a/datasets/shopping.py
+++ b/datasets/shopping.py
@@ -55,6 +55,7 @@ class ShoppingDataset(DatasetInterface):
     description: str = "Give the agent multiple statements adding and removing items from a shopping list. Then ask the agent what is on the shopping list."
     question: str = "What is on my current shopping list? Express the list of items as a JSON list of objects with `item` and `quantity` properties only. Consolidate items that are the same."
     item_changes: int = 3
+    reset_message: str = "I have bought all of the items on the list. Please remove all of the items on the current shopping list."
 
     def generate_examples(self, num_examples):
         renderer = pystache.Renderer()
@@ -116,6 +117,7 @@ class ShoppingDataset(DatasetInterface):
                 evaluation_fn=self.evaluate_correct,
                 number_of_questions=self.count_questions(is_question),
                 is_question=is_question,
+                reset_message=self.reset_message,
             )
 
             examples.append(example)
@@ -130,6 +132,7 @@ class ShoppingDataset(DatasetInterface):
     ) -> Tuple[int, int, List[str]]:
         max_score = len(expected_answers)
         num_correct = 0
+        penalties = 0
         errors = []
         try:
             answer_items = sanitize_and_parse_json(responses[0])
@@ -147,12 +150,15 @@ class ShoppingDataset(DatasetInterface):
                     else:
                         errors.append(f"Wrong quantity for {name}: {item['quantity']} vs {expected_items[key]}.")
                 else:
+                    penalties += 1
                     errors.append(f'Unknown item {name}.')
         except (TypeError, ValueError, JSONDecodeError):
             logging.exception(f"Response not in correct format")
             num_correct = 0
         if num_correct < max_score:
             errors.append(f"{max_score - num_correct} items were not found in the response.")
+
+        num_correct -= penalties
         if num_correct == max_score:
             reasoning = "All items and quantities match."
         else:

--- a/datasets/trigger_response.py
+++ b/datasets/trigger_response.py
@@ -44,6 +44,7 @@ class TriggerResponseDataset(DatasetInterface):
     name: str = "Trigger Response"
     description: str = "Tell the agent to respond in a particular way when a trigger is given. Test the agent."
     trigger_activations: int = 3
+    reset_message: str = "Cancel any instructions as to how you should respond when I whenever I say something in particular."
 
     def generate_examples(self, num_examples):
         examples = []
@@ -74,6 +75,7 @@ class TriggerResponseDataset(DatasetInterface):
                 evaluation_fn=self.evaluate_correct,
                 number_of_questions=self.count_questions(is_question),
                 is_question=is_question,
+                reset_message=self.reset_message
             )
             examples.append(example)
 

--- a/runner/config.py
+++ b/runner/config.py
@@ -8,3 +8,4 @@ class RunConfig:
     run_name: str = field(default_factory=lambda: f"Run {uuid4()}({datetime.now()})")
     debug: bool = False
     incompatibilities: list[list[type]] = field(default_factory=list)
+    continuous_conversation: bool = False

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -314,7 +314,9 @@ class TestRunner:
         return result, skip
 
     def run_interleaved_group(self, test_group: list[TestExample]):
-        self.agent.reset()
+        if not self.config.continuous_conversation:
+            self.agent.reset()
+
         self.result_callbacks = []
         self.group_master_log = []
         results = dict()
@@ -350,6 +352,12 @@ class TestRunner:
                 result = results[example.unique_id]
                 self.progress_dialog.notify_result(result)
                 if not skip:
+                    reset_message = example.reset_message
+                    if self.config.continuous_conversation and reset_message != "":
+                        # The test has finished after running, send the reset message if it exists
+                        action = SendMessageAction(reset_message)
+                        self.log_action(example, action)
+                        self.send_message(action)
                     self.update_result(
                         example=example,
                         result=result,


### PR DESCRIPTION
- Adjusted the scheduler to not reset the Agent between groups
- On test end, the scheduler will send a message to the agent with the `reset_message` set by the `DatasetInterface`
- Tests for `shopping` and `name_list` have more stringent marking requirements. Any extra names/items that are not expected will invoke a penalty point
- Continuous conversations are set in the config  