### PR TITLE
LTM-116 - Keep count of time and tokens wrt the agent

### DIFF
--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -174,7 +174,7 @@ def get_summary_data(run_name: str, agent_name: str):
     return dict(
         speed=len(results) / (benchmark_data["duration"] / 3600),
         cost=benchmark_data["agent_costs_usd"],
-        verbosity=benchmark_data["total_tokens"],
+        verbosity=benchmark_data["agent_tokens"],
         score=score,
         accuracy=100 * accuracy / len(results),
         ltm=ltm_score,

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -54,11 +54,10 @@ class TestRunner:
     in_progress_results: dict[str, TestResult] = field(default_factory=dict)
     traveller: Optional[time_machine.travel] = None
     wait_list: dict[str, dict[str, int | datetime]] = field(default_factory=dict)
-    current_token_count: int = 0
-    avg_tokens_per_second: Optional[float] = None
+    agent_token_count: int = 0
+    total_token_count: int = 0
     test_managing_costs_usd: float = 0
-    benchmark_duration_seconds: float = 0
-    reference_duration_timestamp: Optional[datetime] = None
+    agent_benchmark_duration: float = 0
     skip_evaluations: bool = False
     result_callbacks: List[Tuple[Callable, TestExample]] = field(default_factory=list)
     master_log: MasterLog = None
@@ -73,16 +72,18 @@ class TestRunner:
     def master_log_path(self):
         return make_master_log_path(self.config.run_name, self.agent.name)
 
+    @property
+    def avg_tokens_per_second(self) -> float:
+        return self.agent_token_count / (self.agent_benchmark_duration + 1e-8)
+
     def save_runstats(self):
-        self.update_duration()
         stats = dict(
-            total_tokens=self.current_token_count,
+            total_tokens=self.total_token_count,
+            agent_tokens=self.agent_token_count,
             agent_costs_usd=self.agent.costs_usd,
             managing_costs_usd=self.test_managing_costs_usd,
-            tokens_per_second=self.avg_tokens_per_second,
-            duration=self.benchmark_duration_seconds,
+            duration=self.agent_benchmark_duration,
         )
-
         with open(self.runstats_path, "w") as fd:
             json.dump(stats, fd)
 
@@ -90,15 +91,15 @@ class TestRunner:
         if not self.runstats_path.exists():
             return
         assert (
-            self.avg_tokens_per_second is None and self.reference_duration_timestamp is None
+                self.agent_benchmark_duration == 0
         ), "Attempted to load test scheduler in a non-initial state."
         with open(self.runstats_path) as fd:
             d = json.load(fd)
-        self.current_token_count = d["total_tokens"]
+        self.agent_token_count = d["agent_tokens"]
+        self.total_token_count = d["total_tokens"]
         self.agent.costs_usd = d["agent_costs_usd"]
         self.test_managing_costs_usd = d["managing_costs_usd"]
-        self.avg_tokens_per_second = d["tokens_per_second"]
-        self.benchmark_duration_seconds = d["duration"]
+        self.agent_benchmark_duration = d["duration"]
         self.master_log.load()
 
     def travel_to_dt(self, target_date: datetime):
@@ -113,17 +114,6 @@ class TestRunner:
         target_date = datetime.now() + t_jump
         assert target_date > datetime.now(), "Can only move forward in time. Going back is problematic."
         self.travel_to_dt(target_date)
-
-    def update_duration(self):
-        assert self.reference_duration_timestamp is not None
-        dt = datetime.now()
-        self.reset_time()
-        current_dt = datetime.now()
-        duration = (current_dt - self.reference_duration_timestamp).total_seconds()
-        self.reference_duration_timestamp = current_dt
-        self.benchmark_duration_seconds = (self.benchmark_duration_seconds or 0) + duration
-        if dt > datetime.now():
-            self.travel_to_dt(dt)
 
     def reset_time(self):
         if self.traveller is not None:
@@ -140,35 +130,31 @@ class TestRunner:
                 percentage_finished=action.percentage_finished,
             )
         self.wait_list[unique_id] = dict(
-            tokens=self.current_token_count + action.tokens,
+            tokens=self.total_token_count + action.tokens,
             time=datetime.now() + action.time,
             percentage_finished=action.percentage_finished,
         )
 
-    def send_message(self, test_id: str, action: SendMessageAction):
-        response, sent_ts, reply_ts = self.agent.message_to_agent(action.message)
-        self.debug_message(action.message, response, sent_ts, reply_ts)
-        self.master_log.add_send_message(test_id=test_id, message=action.message, timestamp=sent_ts, is_question=action.is_question)
-        self.master_log.add_response_message(test_id=test_id, message=response, timestamp=reply_ts,  is_question=action.is_question)
-        response_time = (reply_ts - sent_ts).total_seconds()
-        action.reply = response
-        action.reply_ts = reply_ts
-        action.sent_ts = sent_ts
-        action_tokens = token_len(action.message) + token_len(action.reply)
-        self.current_token_count += action_tokens
-        tokens_per_second = action_tokens / (response_time + 1e-5)
-        if self.avg_tokens_per_second is None:
-            self.avg_tokens_per_second = tokens_per_second
-        else:
-            self.avg_tokens_per_second *= 0.9
-            self.avg_tokens_per_second += 0.1 * tokens_per_second
-
-        return action_tokens
+    def send_message(self, test_id: str, action: SendMessageAction) -> int:
+        action.reply, action.sent_ts, action.reply_ts = self.agent.message_to_agent(action.message)
+        self.debug_message(action.message, action.reply, action.sent_ts, action.reply_ts)
+        self.master_log.add_send_message(
+            test_id=test_id, message=action.message, timestamp=action.sent_ts, is_question=action.is_question,
+        )
+        self.master_log.add_response_message(
+            test_id=test_id, message=action.reply, timestamp=action.reply_ts,  is_question=action.is_question
+        )
+        self.agent_benchmark_duration += (action.reply_ts - action.sent_ts).total_seconds()
+        message_tokens = token_len(action.message)
+        reply_tokens = token_len(action.reply)
+        self.agent_token_count += reply_tokens
+        self.total_token_count += message_tokens + reply_tokens
+        return message_tokens + reply_tokens
 
     def get_blocked_test(self, waiting_on: str) -> Optional[str]:
         assert waiting_on in ["tokens", "time", "percentage_finished"]
         target = dict(
-            tokens=self.current_token_count,
+            tokens=self.total_token_count,
             time=datetime.now(),
             percentage_finished=self.percentage_finished,
         )[waiting_on]
@@ -181,7 +167,7 @@ class TestRunner:
         if unique_id not in self.wait_list:
             return False
         wait_dict = self.wait_list[unique_id]
-        if wait_dict["tokens"] > self.current_token_count:
+        if wait_dict["tokens"] > self.total_token_count:
             return True
         if wait_dict["time"] > datetime.now():
             return True
@@ -233,7 +219,7 @@ class TestRunner:
             if token_waiting_id is None:
                 break
             num_tokens = self.wait_list[token_waiting_id]["tokens"]
-            remaining_tokens = num_tokens - self.current_token_count
+            remaining_tokens = num_tokens - self.total_token_count
             while remaining_tokens > 0:
                 msg = filler_no_response_tokens_trivia(remaining_tokens, self.agent.max_message_size)
                 tokens_spent = self.send_message("", SendMessageAction(msg, is_filling=True))
@@ -442,7 +428,6 @@ class TestRunner:
         self.runstats_path.parent.mkdir(parents=True, exist_ok=True)
         self.agent.save_path.mkdir(parents=True, exist_ok=True)
         self.load()
-        self.reference_duration_timestamp = datetime.now()
         self.set_cost_callback()
         colour_print("green", f"Number of tests to run: {len(self.tests)}.")
         self.tests.sort(key=lambda t: t.unique_id)


### PR DESCRIPTION
It doesn't make much sense to count the overall benchmark duration and put it on the final agent's records. In doing it that way, we are including our system's inefficiencies in the agent's statistics.

Tokens are also counted separatedly now. Agent's tokens are used for computing the `avg_tokens_per_second`, instead of having a moving average (which is used nowhere anyway), and also to compute the benchmark speed (tests per hour).