### PR TITLE
Ltm 124 big and small

### DIFF
--- a/dataset_interfaces/factory.py
+++ b/dataset_interfaces/factory.py
@@ -21,6 +21,8 @@ from datasets.chapterbreak import ChapterBreakDataset
 from datasets.restaurant import RestaurantDataset
 from copy import deepcopy
 
+from utils.files import parse_definition_path
+
 DATASETS = {
     "names": NamesDataset,
     "colours": ColourDataset,
@@ -68,8 +70,7 @@ class DatasetFactory:
         args = deepcopy(run_configuration["datasets"]["args"])
 
         # Get the name of the dataset
-
-        path_dataset_name = test_example_path.split(os.sep)[-2]
+        path_dataset_name = parse_definition_path(test_example_path)["dataset_name"]
         dataset = DATASETS_BY_NAME.get(path_dataset_name, None)
 
         if dataset is None:

--- a/dataset_interfaces/factory.py
+++ b/dataset_interfaces/factory.py
@@ -1,4 +1,6 @@
-from dataset_interfaces.interface import TestExample
+import os
+
+from dataset_interfaces.interface import TestExample, DatasetInterface
 from datasets.conficting_personal_information import ConflictingPersonalInformationDataset
 from datasets.delayed_recall import DelayedRecallDataset
 from datasets.how_to_think import HowToThinkDataset
@@ -60,3 +62,33 @@ class DatasetFactory:
             if example.example_id == "":
                 example.example_id = str(i)
         return examples
+
+    @staticmethod
+    def create_dataset_for_example(run_configuration: dict,  test_example_path: str) -> DatasetInterface:
+        args = deepcopy(run_configuration["datasets"]["args"])
+
+        # Get the name of the dataset
+
+        path_dataset_name = test_example_path.split(os.sep)[-2]
+        dataset = DATASETS_BY_NAME.get(path_dataset_name, None)
+
+        if dataset is None:
+            raise ValueError(f"No dataset could be resolved from TestExample path: {test_example_path}. Tried {path_dataset_name}")
+
+        # Use the class to get the 'config name'
+        config_name = ""
+        for name, ds in DATASETS.items():
+            if ds == dataset:
+                config_name = name
+                break
+
+        # Use config name to get any extra config from the run configuration
+        extra_args = {}
+        for dataset_config in run_configuration["datasets"]["datasets"]:
+            if dataset_config["name"] == config_name:
+                extra_args = dataset_config.get("args", {})
+                break
+
+        args.update(extra_args)
+        del args["dataset_examples"]
+        return dataset(**args)

--- a/dataset_interfaces/gpt_generated.py
+++ b/dataset_interfaces/gpt_generated.py
@@ -88,7 +88,3 @@ class GPTGenerated(DatasetInterface, ABC):
         self, questions: List[str], responses: List[str], expected_answers: List[Any]
     ) -> Tuple[int, int, List[str]]:
         return self.evaluate_correct_gpt(questions, responses, expected_answers)
-
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # In GPT-generated tasks, the relevant info is given in the first script line.
-        return 0, 0

--- a/dataset_interfaces/gpt_generated.py
+++ b/dataset_interfaces/gpt_generated.py
@@ -77,7 +77,6 @@ class GPTGenerated(DatasetInterface, ABC):
                 expected_responses=expected_responses,
                 is_question=is_question,
                 uses_callback=self.uses_callback,
-                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/dataset_interfaces/gpt_generated.py
+++ b/dataset_interfaces/gpt_generated.py
@@ -77,6 +77,7 @@ class GPTGenerated(DatasetInterface, ABC):
                 expected_responses=expected_responses,
                 is_question=is_question,
                 uses_callback=self.uses_callback,
+                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/dataset_interfaces/interface.py
+++ b/dataset_interfaces/interface.py
@@ -67,12 +67,13 @@ class SendAndRegisterAction(SendMessageAction):
 class WaitAction(TestAction):
     tokens: int = 0
     time: timedelta = field(default_factory=timedelta)
+    percentage_finished: float = 0.0
 
 
 class WaitCreator:
     @classmethod
-    def create_wait(cls, tokens: int = None, time: timedelta = None):
-        w_dict = {"tokens": tokens, "time": time}
+    def create_wait(cls, tokens: int = None, time: timedelta = None, percentage_finished: float = None):
+        w_dict = {"tokens": tokens, "time": time, "percentage_finished": percentage_finished}
         return {k: v for k, v in w_dict.items() if v is not None}
 
     @classmethod
@@ -105,6 +106,7 @@ class TestExample:
     _iter: Iterator[TestAction] = None
     waits: List[dict] = field(default_factory=list)
     random: Random = None  # Seeded random generator
+    start_token: int = 0
 
     @property
     def dataset_name(self) -> str:

--- a/dataset_interfaces/interface.py
+++ b/dataset_interfaces/interface.py
@@ -209,7 +209,7 @@ class TestExample:
         span_minus_script = memory_span - script_tokens
 
         # Figure out what our spacing is going to be. Just distribute all the needles and questions across 90% of the memory span
-        token_wait = math.floor(span_minus_script * 0.9) // len(self.is_question)
+        token_wait = math.floor(span_minus_script * 0.9) // (len(self.is_question) - 1)
 
         # Create the empty waits if there are any.
         if len(self.waits) == 0:
@@ -227,13 +227,6 @@ class TestExample:
 
         assert total_wait_tokens < span_minus_script, "Sum of task waits is higher than the determined memory span."
         self.waits[-1] = WaitCreator.create_wait()
-
-    def setup_question_ratio(self):
-        # Return normalised values
-        non_questions = len(self.script) - self.number_of_questions
-
-        return non_questions/len(self.script), self.number_of_questions/len(self.script)
-
 
 @dataclass
 class CallBackTestExample(TestExample):

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -11,7 +11,6 @@ Broadly speaking, a `TestExample` consists of a script, some expected responses,
 If inheriting from `DatasetInterface` You should implement the following methods:
 - `generate_examples()` which will return a list of `TestExample` objects.
 - `evaluate_correct` which will take a list of questions, responses and expected answers for one test, and return the score given, the maximum score achievable for the test, and a list of strings explaining why each score was (or was not) given.
-- `answer_statement_idx` which will take a `TestExample` object and return the index of the script line and the index of the character within that script line, after which no more relevant information is given to the agent. This is essential for computing the GoodAI LTM Score.
 
 ### GPTGenerated
 If inheriting from `GPTGenerated` You should write a JSON file containing
@@ -39,7 +38,7 @@ Instead of having a fixed script, dynamic tests are generated on the fly, and th
 Additionally, there are some helper methods available in the base class:
 
 - `say` Returns a `SendMessageAction` object. If `question` is set to `True`, the message will be appended to the test's script.
-- `wait` Returns a `WaitAction` object. If no waiting criteria is set, it defaults to a number of tokens between the high and low limits defined in the dataset class.
+- `wait` Returns a `WaitAction` object.
 - `ask_llm` Calls an OpenAI LLM (by default `gpt-3.5-turbo`) and returns a text response. It also registers the cost of the call as part of the benchmark management costs.
 
 Finally, we encourage you to take a look at the [restaurant task](restaurant.py) for a complete example of how to implement a dynamic test.

--- a/datasets/chapterbreak.py
+++ b/datasets/chapterbreak.py
@@ -156,46 +156,6 @@ class ChapterBreakDataset(DatasetInterface):
 
         return example_list
 
-    def answer_statement_idx(self, example: TestExample) -> tuple[int, int]:
-
-        # Find the message that goes after the last context page
-        last_page_idx = None
-        for i, script_line in enumerate(example.script):
-            if script_line.endswith(
-                " options for the beginning of the next chapter. You don't have to comment anything, just read them "
-                "carefully. Ready?"
-            ):
-                last_page_idx = i - 1
-                break
-        assert last_page_idx is not None
-        context_script = example.script[1:last_page_idx + 1]
-
-        # GoodAI-selected samples contain meta-data for these cases
-        # Find the latest appearance of relevant information
-        if example.example_id in self.selection_info:
-            relevant_sentences = self.selection_info[example.example_id]["ctx"]
-            script_index = char_index = None
-            for line_idx, script_line in reversed(list(enumerate(context_script))):
-                for sentence in relevant_sentences:
-                    i = script_line.find(sentence)
-                    if i < 0:
-                        continue
-                    last_char_i = i + len(sentence)
-                    if script_index is None or char_index < last_char_i:
-                        script_index, char_index = line_idx, last_char_i
-                if script_index is not None:
-                    return script_index + 1, char_index
-
-        # Otherwise, we'll just assume that the key information lies somewhere around the middle of the context.
-        middle_point_chars = sum(len(msg) for msg in context_script) // 2
-        counted_chars = 0
-        for script_answer_index, script_line in enumerate(context_script):
-            counted_chars += len(script_line)
-            if counted_chars > middle_point_chars:
-                break
-        answer_end_char = counted_chars - middle_point_chars
-        return script_answer_index + 1, answer_end_char
-
     def evaluate_correct(
         self, questions: List[str], responses: List[str], expected_answers: List[str]
     ) -> Tuple[int, int, List[str]]:

--- a/datasets/chapterbreak.py
+++ b/datasets/chapterbreak.py
@@ -149,7 +149,8 @@ class ChapterBreakDataset(DatasetInterface):
                 script=script,
                 expected_responses=[str(answer)],
                 is_question=is_question,
-                waits=[WaitCreator.create_wait() for _ in is_question],
+                waits=[WaitCreator.create_wait(tokens=0) for _ in is_question],
+                memory_span=self.memory_span,
             )
             example_list.append(example)
 

--- a/datasets/chapterbreak.py
+++ b/datasets/chapterbreak.py
@@ -150,7 +150,6 @@ class ChapterBreakDataset(DatasetInterface):
                 expected_responses=[str(answer)],
                 is_question=is_question,
                 waits=[WaitCreator.create_wait(tokens=0) for _ in is_question],
-                memory_span=self.memory_span,
             )
             example_list.append(example)
 

--- a/datasets/colours.py
+++ b/datasets/colours.py
@@ -79,12 +79,3 @@ class ColourDataset(DatasetInterface):
             return 1, 1, [f'"{color}" is in the response.']
         return 0, 1, [f'"{color}" is NOT in the response.']
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # The correct answer is the last colour that we told the agent
-        # In this test all statements are atomic
-        current = len(example.script) - 1
-        for idx, text in enumerate(example.script[::-1]):
-            if example.expected_responses[0] in text:
-                current -= idx
-                break
-        return current, len(example.script[current])

--- a/datasets/colours.py
+++ b/datasets/colours.py
@@ -65,6 +65,7 @@ class ColourDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(example)
 

--- a/datasets/colours.py
+++ b/datasets/colours.py
@@ -65,7 +65,6 @@ class ColourDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             examples.append(example)
 

--- a/datasets/delayed_recall.py
+++ b/datasets/delayed_recall.py
@@ -29,4 +29,7 @@ class DelayedRecallDataset(GPTGenerated):
                     "Look, about the fictional world..."
                 ])
                 example.script[i] = f"{intro} {line}"
+                # The number of script lines has changed, redo the waits.
+                example.waits = []
+                example.default_waits()
         return example_list

--- a/datasets/instruction_recall.py
+++ b/datasets/instruction_recall.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from dataclasses import dataclass
+from typing import List
+
 from dataset_interfaces.gpt_generated import GPTGenerated
+from dataset_interfaces.interface import TestExample
 from utils.constants import DATA_DIR
 
 

--- a/datasets/instruction_recall.py
+++ b/datasets/instruction_recall.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from dataclasses import dataclass
-
 from dataset_interfaces.gpt_generated import GPTGenerated
 from utils.constants import DATA_DIR
 

--- a/datasets/instruction_recall.py
+++ b/datasets/instruction_recall.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 from dataclasses import dataclass
-from typing import List
 
 from dataset_interfaces.gpt_generated import GPTGenerated
-from dataset_interfaces.interface import TestExample
 from utils.constants import DATA_DIR
 
 

--- a/datasets/jokes.py
+++ b/datasets/jokes.py
@@ -97,7 +97,9 @@ class JokesDataset(DatasetInterface):
         if hours > 0:
             timestamp = f"{hours} hours " + timestamp
 
-        return f"Which joke did I tell you about {timestamp} ago?"
+        question = f"Which joke did I tell you about {timestamp} ago?"
+        example.script.append(question)
+        return question
 
     def evaluate_correct(
         self, questions: List[str], responses: List[str], expected_answers: List[str]

--- a/datasets/jokes.py
+++ b/datasets/jokes.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Tuple
@@ -40,6 +41,8 @@ class JokesDataset(DatasetInterface):
             is_question = []
             jokes = deepcopy(JOKES)
             waits = []
+
+            filler_tokens = math.floor(self.memory_span * 0.75) // self.jokes_told
             for joke_made in range(self.jokes_told):
                 if len(jokes) == 0:
                     logging.warning("Ran out of jokes")
@@ -53,7 +56,7 @@ class JokesDataset(DatasetInterface):
                 selected_jokes.append(joke)
                 is_question.append(False)
                 time_jump = create_time_jump(self.minutes_low, self.minutes_high)
-                waits.append(WaitCreator.create_wait(tokens=self.filler_tokens, time=time_jump))
+                waits.append(WaitCreator.create_wait(tokens=filler_tokens, time=time_jump))
 
             # Choose the joke we are going to look at
             answer = self.random.choice(selected_jokes)
@@ -106,16 +109,6 @@ class JokesDataset(DatasetInterface):
             return score, max_score, reasons
         else:
             return self.evaluate_correct_gpt(questions, responses, expected_answers)
-
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        statements = example.script
-
-        for idx, statement in enumerate(statements):
-            answer_idx = statement.find(example.expected_responses[0])
-            if answer_idx >= 0:
-                return idx, answer_idx + len(example.expected_responses[0])
-
-        raise ValueError("Issue in getting where joke was told")
 
 
 if __name__ == "__main__":

--- a/datasets/jokes.py
+++ b/datasets/jokes.py
@@ -70,6 +70,7 @@ class JokesDataset(DatasetInterface):
                 waits=waits,
                 is_temporal=True,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/jokes.py
+++ b/datasets/jokes.py
@@ -73,7 +73,6 @@ class JokesDataset(DatasetInterface):
                 waits=waits,
                 is_temporal=True,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/kv.py
+++ b/datasets/kv.py
@@ -59,6 +59,7 @@ class KVPairsDataset(DatasetInterface):
                 script=script,
                 expected_responses=[value],
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(test_example)
         return examples

--- a/datasets/kv.py
+++ b/datasets/kv.py
@@ -59,7 +59,6 @@ class KVPairsDataset(DatasetInterface):
                 script=script,
                 expected_responses=[value],
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             examples.append(test_example)
         return examples

--- a/datasets/kv.py
+++ b/datasets/kv.py
@@ -70,10 +70,3 @@ class KVPairsDataset(DatasetInterface):
         reasoning = getsource(KVPairsDataset.evaluate_correct)
         return int(expected_answers[0] in responses[0]), 1, [reasoning]
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # This is a single message test, so the relevant information is in that message.
-        # Need to get the position after the relevant information inside the statement
-        string_pos = example.script[0].find(example.expected_responses[0]) + len(
-            example.expected_responses[0]
-        )
-        return 0, string_pos

--- a/datasets/locations.py
+++ b/datasets/locations.py
@@ -215,7 +215,3 @@ class LocationsDataset(DatasetInterface):
 
         return [f"{distance} km {direction}"]
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # All statements are relevant
-        # in this test all statements are atomic
-        return 0, len(example.script[0])

--- a/datasets/locations.py
+++ b/datasets/locations.py
@@ -115,7 +115,6 @@ class LocationsDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/locations.py
+++ b/datasets/locations.py
@@ -115,6 +115,7 @@ class LocationsDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/multisessionchat.py
+++ b/datasets/multisessionchat.py
@@ -206,6 +206,3 @@ class MultiSessionChatDataset(DatasetInterface):
         except (json.JSONDecodeError, KeyError) as exc:
             return 0, 1, [str(exc)]
 
-    def answer_statement_idx(self, example: TestExample) -> tuple[int, int]:
-        # TODO: try to figure out where the relevant information actually is
-        return 0, len(example.script[0]) // 2

--- a/datasets/multisessionchat.py
+++ b/datasets/multisessionchat.py
@@ -174,6 +174,7 @@ class MultiSessionChatDataset(DatasetInterface):
                 script=script,
                 expected_responses=[json.dumps(answer_data)],
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             test_examples.append(example)
         return test_examples

--- a/datasets/multisessionchat.py
+++ b/datasets/multisessionchat.py
@@ -174,7 +174,6 @@ class MultiSessionChatDataset(DatasetInterface):
                 script=script,
                 expected_responses=[json.dumps(answer_data)],
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             test_examples.append(example)
         return test_examples

--- a/datasets/name.py
+++ b/datasets/name.py
@@ -50,7 +50,6 @@ class NamesDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             examples.append(example)
         return examples

--- a/datasets/name.py
+++ b/datasets/name.py
@@ -63,12 +63,3 @@ class NamesDataset(DatasetInterface):
             return 1, 1, [f'"{name}" is in the response.']
         return 0, 1, [f'"{name}" is NOT in the response.']
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # The correct answer is the last name that we told the agent
-        # In this test all statements are atomic
-        current = len(example.script) - 1
-        for idx, text in enumerate(example.script[::-1]):
-            if example.expected_responses[0] in text:
-                current -= idx
-                break
-        return current, len(example.script[current])

--- a/datasets/name.py
+++ b/datasets/name.py
@@ -50,6 +50,7 @@ class NamesDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(example)
         return examples

--- a/datasets/name_list.py
+++ b/datasets/name_list.py
@@ -92,7 +92,3 @@ class NameListDataset(DatasetInterface):
 
         return score, len(expected_answers), reasoning
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # All statements are relevant
-        # in this test all statements are atomic
-        return 0, len(example.script[0])

--- a/datasets/name_list.py
+++ b/datasets/name_list.py
@@ -53,7 +53,6 @@ class NameListDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             examples.append(example)
         return examples

--- a/datasets/name_list.py
+++ b/datasets/name_list.py
@@ -53,6 +53,7 @@ class NameListDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(example)
         return examples

--- a/datasets/restaurant.py
+++ b/datasets/restaurant.py
@@ -36,7 +36,7 @@ class RestaurantExample(DynamicExample):
             "When I talk to you as the waiter ('Waiter: what will it be sir?'), then you will reply as if you were the "
             "customer at a restaurant. Give straight answers to the questions and avoid going off script. Understood?"
         )
-        yield self.wait(percentage_finished=20)
+        yield self.wait(tokens=self.memory_span * .2)
 
         # Give the menu and ask for the drink
         yield self.say(
@@ -49,14 +49,14 @@ class RestaurantExample(DynamicExample):
         drinks = self.extract_order_items(self.action.reply)
         drinks_str = enumerate_str(drinks)
         self.reasoning.append(f"The agent answered as the customer and ordered {drinks_str}.")
-        yield self.wait(percentage_finished=40)
+        yield self.wait(tokens=self.memory_span * .2)
 
         # Ordering food
         yield self.say(f"Here is your {drinks_str}. What would you like to eat?")
         order = self.extract_order_items(self.action.reply)
         order_str = self.score_and_format_order(order)
         yield self.say(f"Excellent choice! {order_str} coming right up.", question=False)
-        yield self.wait(percentage_finished=60)
+        yield self.wait(tokens=self.memory_span * .2)
 
         # Some dish is unexpectedly unavailable -> order another thing
         old_item = self.random.choice(order)
@@ -80,7 +80,7 @@ class RestaurantExample(DynamicExample):
         order.remove(old_item)
         order.extend(new_items)
         yield self.say(f"{new_items_str} it is. Sorry again for the inconvenience.", question=False)
-        yield self.wait(percentage_finished=80)
+        yield self.wait(tokens=self.memory_span * .2)
 
         # Alter the order -> does the agent notice?
         true_item, unsolicited_item, altered_order = self.alter_order(order, old_item)
@@ -88,7 +88,7 @@ class RestaurantExample(DynamicExample):
         yield self.say(f"Here you are: {altered_str}. Enjoy the meal.")
         self.check_notices_mishap()
         yield self.say("I apologize. I will fix it immediately.", question=False)
-        yield self.wait(percentage_finished=100)
+        yield self.wait(tokens=self.memory_span * .1)
 
         # Amend the order and offer an extra drink
         yield self.say(

--- a/datasets/restaurant.py
+++ b/datasets/restaurant.py
@@ -36,7 +36,7 @@ class RestaurantExample(DynamicExample):
             "When I talk to you as the waiter ('Waiter: what will it be sir?'), then you will reply as if you were the "
             "customer at a restaurant. Give straight answers to the questions and avoid going off script. Understood?"
         )
-        yield self.wait(tokens=self.memory_span * .2)
+        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
 
         # Give the menu and ask for the drink
         yield self.say(
@@ -49,14 +49,14 @@ class RestaurantExample(DynamicExample):
         drinks = self.extract_order_items(self.action.reply)
         drinks_str = enumerate_str(drinks)
         self.reasoning.append(f"The agent answered as the customer and ordered {drinks_str}.")
-        yield self.wait(tokens=self.memory_span * .2)
+        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
 
         # Ordering food
         yield self.say(f"Here is your {drinks_str}. What would you like to eat?")
         order = self.extract_order_items(self.action.reply)
         order_str = self.score_and_format_order(order)
         yield self.say(f"Excellent choice! {order_str} coming right up.", question=False)
-        yield self.wait(tokens=self.memory_span * .2)
+        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
 
         # Some dish is unexpectedly unavailable -> order another thing
         old_item = self.random.choice(order)
@@ -80,7 +80,7 @@ class RestaurantExample(DynamicExample):
         order.remove(old_item)
         order.extend(new_items)
         yield self.say(f"{new_items_str} it is. Sorry again for the inconvenience.", question=False)
-        yield self.wait(tokens=self.memory_span * .2)
+        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
 
         # Alter the order -> does the agent notice?
         true_item, unsolicited_item, altered_order = self.alter_order(order, old_item)
@@ -88,7 +88,7 @@ class RestaurantExample(DynamicExample):
         yield self.say(f"Here you are: {altered_str}. Enjoy the meal.")
         self.check_notices_mishap()
         yield self.say("I apologize. I will fix it immediately.", question=False)
-        yield self.wait(tokens=self.memory_span * .1)
+        yield self.wait(tokens=self.dataset_generator.memory_span * .1)
 
         # Amend the order and offer an extra drink
         yield self.say(

--- a/datasets/restaurant.py
+++ b/datasets/restaurant.py
@@ -36,7 +36,7 @@ class RestaurantExample(DynamicExample):
             "When I talk to you as the waiter ('Waiter: what will it be sir?'), then you will reply as if you were the "
             "customer at a restaurant. Give straight answers to the questions and avoid going off script. Understood?"
         )
-        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
+        yield self.wait(percentage_finished=20)
 
         # Give the menu and ask for the drink
         yield self.say(
@@ -49,14 +49,14 @@ class RestaurantExample(DynamicExample):
         drinks = self.extract_order_items(self.action.reply)
         drinks_str = enumerate_str(drinks)
         self.reasoning.append(f"The agent answered as the customer and ordered {drinks_str}.")
-        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
+        yield self.wait(percentage_finished=40)
 
         # Ordering food
         yield self.say(f"Here is your {drinks_str}. What would you like to eat?")
         order = self.extract_order_items(self.action.reply)
         order_str = self.score_and_format_order(order)
         yield self.say(f"Excellent choice! {order_str} coming right up.", question=False)
-        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
+        yield self.wait(percentage_finished=60)
 
         # Some dish is unexpectedly unavailable -> order another thing
         old_item = self.random.choice(order)
@@ -80,7 +80,7 @@ class RestaurantExample(DynamicExample):
         order.remove(old_item)
         order.extend(new_items)
         yield self.say(f"{new_items_str} it is. Sorry again for the inconvenience.", question=False)
-        yield self.wait(tokens=self.dataset_generator.memory_span * .2)
+        yield self.wait(percentage_finished=80)
 
         # Alter the order -> does the agent notice?
         true_item, unsolicited_item, altered_order = self.alter_order(order, old_item)
@@ -88,7 +88,7 @@ class RestaurantExample(DynamicExample):
         yield self.say(f"Here you are: {altered_str}. Enjoy the meal.")
         self.check_notices_mishap()
         yield self.say("I apologize. I will fix it immediately.", question=False)
-        yield self.wait(tokens=self.dataset_generator.memory_span * .1)
+        yield self.wait(percentage_finished=90)
 
         # Amend the order and offer an extra drink
         yield self.say(

--- a/datasets/restaurant.py
+++ b/datasets/restaurant.py
@@ -224,9 +224,6 @@ class RestaurantDataset(DynamicDataset):
             for section, content in self.menu_dict.items()
         )
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        return 0, len(example.script[0])
-
 
 def day_moment_salutation() -> str:
     ts = datetime.now()

--- a/datasets/sally_ann.py
+++ b/datasets/sally_ann.py
@@ -92,7 +92,3 @@ class SallyAnneDataset(DatasetInterface):
             reasoning = f"Invalid answer: {answer_dict}"
         return score, max_score, [reasoning]
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # All statements are relevant
-        # in this test all statements are atomic
-        return 0, len(example.script[0])

--- a/datasets/sally_ann.py
+++ b/datasets/sally_ann.py
@@ -66,7 +66,6 @@ class SallyAnneDataset(DatasetInterface):
                 script=script,
                 expected_responses=[answer],
                 is_question=is_question,
-
             )
             examples.append(example)
 

--- a/datasets/sally_ann.py
+++ b/datasets/sally_ann.py
@@ -66,7 +66,7 @@ class SallyAnneDataset(DatasetInterface):
                 script=script,
                 expected_responses=[answer],
                 is_question=is_question,
-                memory_span=self.memory_span,
+
             )
             examples.append(example)
 

--- a/datasets/sally_ann.py
+++ b/datasets/sally_ann.py
@@ -66,6 +66,7 @@ class SallyAnneDataset(DatasetInterface):
                 script=script,
                 expected_responses=[answer],
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(example)
 

--- a/datasets/shopping.py
+++ b/datasets/shopping.py
@@ -113,7 +113,6 @@ class ShoppingDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/shopping.py
+++ b/datasets/shopping.py
@@ -188,11 +188,6 @@ class ShoppingDataset(DatasetInterface):
         score = (score / 3) * max_score
         return score, max_score, ["\n".join(reasoning)]
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # All statements are relevant
-        # in this test all statements are atomic
-        return 0, len(example.script[0])
-
 
 def main():
     # Create a conversation for the agent using a name and phil

--- a/datasets/shopping.py
+++ b/datasets/shopping.py
@@ -113,6 +113,7 @@ class ShoppingDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
 
             examples.append(example)

--- a/datasets/spy_meeting.py
+++ b/datasets/spy_meeting.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import Tuple, List
 
@@ -79,7 +78,6 @@ class SpyMeetingDataset(DatasetInterface):
                 script=script,
                 is_question=is_question,
                 expected_responses=expected_responses,
-                memory_span=self.memory_span,
             ))
 
         return examples

--- a/datasets/spy_meeting.py
+++ b/datasets/spy_meeting.py
@@ -105,8 +105,4 @@ class SpyMeetingDataset(DatasetInterface):
 
         return correct, 1, reasoning
 
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # Second statement in the script, character 0
-        return 1, 0
-
 

--- a/datasets/spy_meeting.py
+++ b/datasets/spy_meeting.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Tuple, List
 
@@ -51,7 +52,6 @@ class SpyMeetingDataset(DatasetInterface):
             for k in range(3):
                 names.append(faker.unique.name())
 
-            waits = [WaitCreator.create_wait(percentage_finished=10)]
             is_question = [False]
             script = [f"You will be given three messages from different people {names[0]}, {names[1]}, and {names[2]}."]
             topic_list = [(CODED_INFO_TIME, TIME_TEMPLATE), (CODED_INFO_THING, THING_TEMPLATE), (CODED_INFO_PLACE, PLACE_TEMPLATE)]
@@ -71,21 +71,15 @@ class SpyMeetingDataset(DatasetInterface):
                 is_question.append(False)
                 expected_responses.append(potential_interpretations)
 
-                if k == 2:
-                    waits.append(WaitCreator.create_wait(percentage_finished=90))
-                else:
-                    waits.append(WaitCreator.create_wait(percentage_finished=(k+2) * 10))
-
             script.append(self.question)
             is_question.append(True)
-            waits.append(waits)
 
             examples.append(TestExample(
                 dataset_generator=self,
                 script=script,
-                waits=waits,
                 is_question=is_question,
-                expected_responses=expected_responses
+                expected_responses=expected_responses,
+                memory_span=self.memory_span,
             ))
 
         return examples

--- a/datasets/trigger_response.py
+++ b/datasets/trigger_response.py
@@ -94,6 +94,7 @@ class TriggerResponseDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
+                memory_span=self.memory_span,
             )
             examples.append(example)
 

--- a/datasets/trigger_response.py
+++ b/datasets/trigger_response.py
@@ -94,7 +94,6 @@ class TriggerResponseDataset(DatasetInterface):
                 script=script,
                 expected_responses=answer_list,
                 is_question=is_question,
-                memory_span=self.memory_span,
             )
             examples.append(example)
 

--- a/datasets/trigger_response.py
+++ b/datasets/trigger_response.py
@@ -126,8 +126,3 @@ class TriggerResponseDataset(DatasetInterface):
             score += score_single
             reasoning.append(reasoning_single)
         return score, max_score, reasoning
-
-    def answer_statement_idx(self, example: TestExample) -> Tuple[int, int]:
-        # All statements are relevant
-        # in this test all statements are atomic
-        return 0, len(example.script[0])

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -49,7 +49,7 @@ def arrange_data(results: List[TestResult]):
     run_name = results[0].run_name
     agent_name = results[0].agent_name
     max_score = achieved_score = 0
-    info_gaps = list()
+    memory_spans = list()
     data = dict()
 
     for res in results:
@@ -65,7 +65,7 @@ def arrange_data(results: List[TestResult]):
 
         max_score += res.max_score
         achieved_score += res.score
-        info_gaps.append(res.tokens)
+        memory_spans.append(res.tokens)
 
         expected = [str(r) for r in res.expected_responses]
         actual = [str(r) for r in res.actual_responses]
@@ -100,13 +100,13 @@ def arrange_data(results: List[TestResult]):
     return dict(
         achieved_score=display_float_or_int(achieved_score),
         max_score=display_float_or_int(max_score),
-        info_gap=0,  # TODO
+        target_memory_span=args["memory_span"],
         run_name=run_name,
         agent_name=agent_name,
         data_by_dataset=data,
-        min_gap=min(info_gaps),
-        max_gap=max(info_gaps),
-        avg_gap=int(sum(info_gaps)/len(info_gaps)),
+        min_gap=min(memory_spans),
+        max_gap=max(memory_spans),
+        avg_gap=int(sum(memory_spans)/len(memory_spans)),
     )
 
 

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -100,7 +100,7 @@ def arrange_data(results: List[TestResult]):
     return dict(
         achieved_score=display_float_or_int(achieved_score),
         max_score=display_float_or_int(max_score),
-        info_gap=max(args["filler_tokens"], args["pre_question_filler"]),
+        info_gap=0,  # TODO
         run_name=run_name,
         agent_name=agent_name,
         data_by_dataset=data,

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -90,6 +90,7 @@ def arrange_data(results: List[TestResult]):
             "tokens": res.tokens,
             "characters": res.characters,
             "color": color,
+            "needles": res.needles,
         }
         data[res.dataset_name]["tests"].append(test_dict)
 

--- a/reporting/results.py
+++ b/reporting/results.py
@@ -23,6 +23,7 @@ class TestResult:
     characters: int = None
     repetition: int = 0
     full_log: List[str] = field(default_factory=list)
+    needles: int = 0
 
     def __post_init__(self):
         self._saved_attrs = [
@@ -35,6 +36,7 @@ class TestResult:
             "characters",
             "full_log",
             "expected_responses",
+            "needles"
         ]
 
     def __str__(self):

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -108,6 +108,7 @@
                             <b>Test {{ test_idx + 1 }} ({{ test.score }}/{{ test.max_score }})</b>
                         </div>
                         <div class="test-details">
+                            <p><b>Needles: {{ test.needles }}</b></p>
                             <p><b>Task Log:</b></p>
                             <ul style="list-style-type:none;">
                             {% for line in test.task_log %}

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -105,7 +105,12 @@
                     <div class="test">
                         <div class="test-title" onclick="toggleNextSibling(this);event.stopPropagation();"
                         style="background-color: {{ test.color }};">
-                            <b>Test {{ test_idx + 1 }} ({{ test.score }}/{{ test.max_score }})</b>
+                            <b>
+                                Test {{ test_idx + 1 }} ({{ test.score }}/{{ test.max_score }})
+                                {% if test.tokens > target_memory_span %}
+                                    - MEMORY SPAN OVERRUN: Tokens: {{ test.tokens }} > {{ target_memory_span }}
+                                {% endif %}
+                            </b>
                         </div>
                         <div class="test-details">
                             <p><b>Needles: {{ test.needles }}</b></p>

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -87,7 +87,7 @@
     <div class="main-title">
         <img src="data:image/png;base64, {{ logo_b64 }}" alt="GoodAI Logo" />
         <h1>GoodAI LTM Benchmark</h1>
-        <p><b>Distraction Segment</b>: {{ info_gap }} tokens<br><b>Memory Span (Min/Avg/Max)</b>: {{ min_gap }} <b>/</b> {{ avg_gap }} <b>/</b> {{ max_gap }} tokens</p>
+        <p><b>Target Max Memory Span</b>: {{ target_memory_span }} tokens<br><b>Actual Test Memory Spans (Min/Avg/Max)</b>: {{ min_gap }} <b>/</b> {{ avg_gap }} <b>/</b> {{ max_gap }} tokens</p>
         <p><b>Agent</b>: {{ agent_name }}<br><b>Overall score</b>: {{ achieved_score }} <b>/</b> {{ max_score }}</p>
         <ul>
             {% for metric in global_metrics %}
@@ -122,7 +122,7 @@
                                 <hr>
                             {% endfor %}
                             <p><b>Score:</b> {{ test.score }}/{{ test.max_score }}</p>
-                            <p><b>Distance to relevant info:</b> {{ test.tokens }} tokens, {{ test.characters }} characters.</p>
+                            <p><b>Memory span from first statement to last question:</b> {{ test.tokens }} tokens, {{ test.characters }} characters.</p>
                         </div>
                     </div>
                 {% endfor %}

--- a/runner/master_log.py
+++ b/runner/master_log.py
@@ -69,13 +69,12 @@ class MasterLog:
         timestamp: datetime,
         tokens: int = 0,
         time: timedelta = timedelta(seconds=0),
-        percentage_finished: float = 0.0
     ):
         event = LogEvent(
             EventType.WAIT,
             timestamp=timestamp,
             test_id=test_id,
-            data={"tokens": tokens, "time": time, "percentage_finished": percentage_finished},
+            data={"tokens": tokens, "time": time},
         )
         self.add_event(event)
 
@@ -119,8 +118,6 @@ class MasterLog:
                     wait_cond.append(f"{event.data['tokens']} TOKENS")
                 if event.data['time'].seconds > 0:
                     wait_cond.append(f"{event.data['time']} TIME")
-                if event.data['percentage_finished'] > 0:
-                    wait_cond.append(f"{event.data['percentage_finished']}% TESTS FINISHED")
                 wait_cond = ", ".join(wait_cond)
 
                 messages.append(f"SYSTEM ({event.timestamp}): Test '{event.test_id}' WAITING for {wait_cond}.")

--- a/runner/master_log.py
+++ b/runner/master_log.py
@@ -79,8 +79,8 @@ class MasterLog:
         )
         self.add_event(event)
 
-    def begin_test(self, test_id, timestamp):
-        event = LogEvent(EventType.BEGIN, timestamp=timestamp, test_id=test_id)
+    def begin_test(self, test_id, timestamp, tokens):
+        event = LogEvent(EventType.BEGIN, timestamp=timestamp, test_id=test_id, data={"tokens": tokens})
         self.add_event(event)
 
     def end_test(self, test_id: str, timestamp: datetime):
@@ -191,22 +191,12 @@ class MasterLog:
 
         return context
 
-    def tokens_before_event(self, event: LogEvent) -> int:
-        event_idx = self.event_idx(event)
+    def get_start_token(self, test_id: str):
+        for event in self.log:
+            if event.test_id == test_id and event.type == EventType.BEGIN:
+                return event.data["tokens"]
 
-        tokens = 0
-        for evt in self.log[:event_idx]:
-            if evt.type in [EventType.SEND_MESSAGE, EventType.SEND_FILL, EventType.RESPONSE_MESSAGE, EventType.RESPONSE_FILL]:
-                tokens += token_len(evt.data["message"])
-
-        return tokens
-
-    def event_idx(self, event: LogEvent):
-        for idx, evt in enumerate(self.log):
-            if evt == event:
-                return idx
-
-        raise ValueError(f"Event not found in log! {event}")
+        raise ValueError(f"Test with id {test_id} has not started.")
 
     def get_questions_and_responses(self, test_id: str):
         questions = []

--- a/runner/run_benchmark.py
+++ b/runner/run_benchmark.py
@@ -91,7 +91,7 @@ def generate_test_examples(
                 f"There are test definitions in disk for run name {run_name}",
                 question="Do you want to reuse these test definitions?",
             ):
-                return [TestExample.load(p) for p in test_definitions]
+                return load_test_examples(loaded_yaml, test_definitions)
             if not ask_yesno(
                 "WARNING: overwriting the test definitions will result in the loss of all "
                 "results associated with them, including those from other agents.",
@@ -113,6 +113,16 @@ def generate_test_examples(
 
     for example in examples:
         example.save(run_name)
+
+    return examples
+
+
+def load_test_examples(yaml_configuration, test_definition_paths: list[str]) -> list[TestExample]:
+
+    examples = []
+    for p in test_definition_paths:
+        dataset = DatasetFactory.create_dataset_for_example(yaml_configuration, p)
+        examples.append(TestExample.load(dataset, p))
 
     return examples
 

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -315,7 +315,6 @@ class TestRunner:
             max_score=1,
             score=1,
             reasoning=["Evaluation Skipped"],
-            needles=len(example.script) - example.number_of_questions
         )
         skip = result.path.exists()
         if skip:

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -315,6 +315,7 @@ class TestRunner:
             max_score=1,
             score=1,
             reasoning=["Evaluation Skipped"],
+            needles=len(example.script) - example.number_of_questions
         )
         skip = result.path.exists()
         if skip:
@@ -458,6 +459,7 @@ class TestRunner:
                 result.max_score = max_score
                 result.reasoning = reason
 
+        result.needles = len(example.script) - example.number_of_questions
         result.task_log = task_log
         result.actual_responses = question_responses
         result.tokens = tokens

--- a/utils/files.py
+++ b/utils/files.py
@@ -60,3 +60,12 @@ def parse_result_path(path: Path | str) -> dict[str, str]:
         example_id="_".join(name_parts[:-1]),
         repetition=int(name_parts[-1])
     )
+
+
+def parse_definition_path(path: Path | str) -> dict[str, str]:
+    benchmark_name, _, dataset_name, definition_fname = Path(path).as_posix().split("/")[-4:]
+    return dict(
+        benchmark_name=benchmark_name,
+        dataset_name=dataset_name,
+        example_id=int(definition_fname.removesuffix(".def.json"))
+    )

--- a/utils/filling_task.py
+++ b/utils/filling_task.py
@@ -50,12 +50,16 @@ def filler_no_response_tokens_trivia(num_tokens: int, max_message_size: int):
     tokens_to_return = min(num_tokens, max_message_size)
     total_tokens = token_len(message)
     messages = [message]
+    answers = []
     at_least_one_trivia = False
+    est_response_tokens = 0
 
-    while not at_least_one_trivia or total_tokens < tokens_to_return:
+    while not at_least_one_trivia or (total_tokens + est_response_tokens) < tokens_to_return:
         trivia = random.choice(data)
         trivia_msg = f"Q: {trivia['Question']}, A: {trivia['AnswerValue']}\n"
+        answers.append(trivia['AnswerValue'])
         total_tokens += token_len(trivia_msg)
+        est_response_tokens = token_len(str(answers))
         messages.append(trivia_msg)
         at_least_one_trivia = True
 

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -157,3 +157,13 @@ def context_token_len(context: LLMContext, model: Optional[str] = None, response
     if response:
         num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
     return num_tokens
+
+
+def get_tokens_for_script(script: list[str], model: Optional[str] = None) -> int:
+    encoder = tiktoken.encoding_for_model(get_model(model))
+    num_tokens = 0
+    for line in script:
+        num_tokens += 4
+        num_tokens += len(encoder.encode(line))
+
+    return num_tokens


### PR DESCRIPTION
Big and small numbers:

- Big numbers now guarantees that the memory span of a test will be less than the big number.
- Filler token values are removed, waits are calculated on either a 75/25 context split, or a 50/50 split if `number_of_questions > 1`
- Setup statements are uniformly distributed across the first number in the split, questions are uniformly distributed across 90% of the second number
- When calculating filler, we now also take into account the length of the probable response (which is a list of the answers). This means that the filler consists of the trivia + agent response and that length is more true to the number of filler tokens we desire.
- Percentage waiting has been removed - it doesn't make sense in the context of the big number.
- Nomenclature in reports has been changed and terms related to memory span have been cleared up a little.
- On creating waits, we have assertions to filter out datasets that have more data than the memory span.
- Waits are now the responsibility of the `TestExample`, not of the `DatasetGenerator` This was done to try and reduce the dependency of `TestExample` initialisation on the `DatasetGenerator`. What was happening is that The DatasetGenerator was creating the TestExample, which then called the DatasetGenerator in `__post_init__`. Which was strange and added odd dependencies on information in the `DatasetGenerator` that would also be needed at load time, but we don't save the generators, so it was all very complicated.  
- `answer_statement_idx` is gone, the memory span is calculated from the first statement to the last.
- Detailed reports now show how many needles are in a test.