### PR TITLE
LTM-134 - Results aggregation

### DIFF
--- a/reporting/detailed_report.py
+++ b/reporting/detailed_report.py
@@ -7,8 +7,9 @@ from reporting.generate import gather_results, generate_report
 @click.argument("run_name", type=str)
 @click.argument("agent_name", type=str)
 @click.option("-o", "--output", type=str, required=False, default=None, help="Name of the resulting report, without extension.")
+@click.option("-s", "--show", type=bool, required=False, default=True, help="Show the report in a new browser tab.")
 def main(run_name: str, agent_name: str, output: str, show: bool):
-    _main(run_name, agent_name, output)
+    _main(run_name, agent_name, output, show)
 
 
 def _main(run_name: str, agent_name: str, output: str, show: bool = True):

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -1,16 +1,16 @@
 import os
 import json
 import re
-import numpy as np
 import yaml
 from typing import List, Optional
 from random import Random
 from jinja2 import Environment, FileSystemLoader
 from reporting.results import TestResult
 from utils.files import gather_result_files, gather_runstats_files, make_config_path
-from utils.constants import REPORT_TEMPLATES_DIR, MAIN_DIR, GOODAI_RED, GOODAI_GREEN, METRIC_NAMES, METRIC_ALT, \
+from utils.constants import REPORT_TEMPLATES_DIR, GOODAI_RED, GOODAI_GREEN, METRIC_NAMES, METRIC_ALT, \
     METRIC_UNITS, SPIDER_LABELS_OVERRIDE, REPORT_OUTPUT_DIR
 from utils.data import load_b64
+from utils.math import mean_std
 from utils.ui import display_float_or_int
 from datetime import datetime
 from pathlib import Path
@@ -169,10 +169,8 @@ def normalize_and_aggregate_results(results: list[TestResult]) -> dict[str, dict
     for d in result_dict.values():
         norm_scores = [r.score / r.max_score for r in d["results"]]
         ltm_scores = [r.tokens for r in d["results"]]
-        d["score"] = np.mean(norm_scores)
-        d["std"] = np.std(norm_scores)
-        d["ltm"] = np.mean(ltm_scores)
-        d["ltm_std"] = np.std(ltm_scores)
+        d["score"], d["std"] = mean_std(norm_scores)
+        d["ltm"], d["ltm_std"] = mean_std(ltm_scores)
 
     return result_dict
 

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -60,6 +60,7 @@ def arrange_data(results: List[TestResult]):
                 "name": res.dataset_name,
                 "description": res.description,
                 "tests": [],
+                "scores": [],
             }
 
         memory_spans.append(res.tokens)
@@ -90,6 +91,12 @@ def arrange_data(results: List[TestResult]):
             "needles": res.needles,
         }
         data[res.dataset_name]["tests"].append(test_dict)
+        data[res.dataset_name]["scores"].append(res.score / res.max_score)
+
+    for dataset_results in data.values():
+        score, std = mean_std(dataset_results.pop("scores"))
+        dataset_results["score"] = display_float_or_int(score)
+        dataset_results["score_std"] = display_float_or_int(std)
 
     with open(make_config_path(run_name)) as fd:
         config = yaml.safe_load(fd)

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -191,7 +191,7 @@ def get_summary_data(run_name: str, agent_name: str):
         ltm_score_std += dataset_results["ltm_std"]
 
     return dict(
-        speed=len(results) / (benchmark_data["duration"] / 3600),  # tests per hour
+        speed=benchmark_data["agent_tokens"] / benchmark_data["duration"],
         cost=benchmark_data["agent_costs_usd"],
         verbosity=benchmark_data["agent_tokens"],
         score=score,

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -88,7 +88,7 @@
         <img src="data:image/png;base64, {{ logo_b64 }}" alt="GoodAI Logo" />
         <h1>GoodAI LTM Benchmark</h1>
         <p><b>Target Max Memory Span</b>: {{ target_memory_span }} tokens<br><b>Actual Test Memory Spans (Min/Avg/Max)</b>: {{ min_gap }} <b>/</b> {{ avg_gap }} <b>/</b> {{ max_gap }} tokens</p>
-        <p><b>Agent</b>: {{ agent_name }}<br><b>Overall score</b>: {{ achieved_score }} <b>/</b> {{ max_score }}</p>
+        <p><b>Agent</b>: {{ agent_name }}<br><b>Overall score</b>: {{ achieved_score }} <b>/</b> {{ max_score }} <b>±</b> {{ score_std }}</p>
         <ul>
             {% for metric in global_metrics %}
                 <li title="{{ metric.alt }}"><b>{{ metric.name }}</b>: {{ metric.value }} {{ metric.units }}</li>

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -99,7 +99,7 @@
         <h1>{{ run_name }}</h1>
         {% for dataset_name, dataset in sorted(data_by_dataset.items()) %}
             <div class="dataset" id="{{ dataset_name }}">
-                <h1>{{ dataset.name }}</h1>
+                <h1>{{ dataset.name }} ({{ dataset.score }} ± {{ dataset.score_std }})</h1>
                 <p class="description">{{ dataset.description }}</p>
                 {% for test_idx, test in enumerate(dataset.tests) %}
                     <div class="test">

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,3 @@ browser-cookie3
 langchain==0.1.1
 langchain-openai==0.0.2
 rouge_score==0.1.2
-numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ browser-cookie3
 langchain==0.1.1
 langchain-openai==0.0.2
 rouge_score==0.1.2
+numpy

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -42,20 +42,17 @@ METRIC_ALT = dict(
         "maximum score possible for that test. We then average all tests' accuracies together. This can be viewed "
         "as a uniformly-weighted score average."
     ),
-    speed=(
-        "(Average Tests per Hour) How many tests, on average, the agent completes within an hour of running the "
-        "benchmark."
-    ),
+    speed="(Average Tokens per Second) How quickly the agent responds and outputs text.",
     cost=(
         "(USD) Overall cost of running the agent for the whole benchmark, in US dollars. We use the negative value to "
         "obtain the Economy."
     ),
     verbosity=(
-        "(Tokens) The number of tokens that comprise the complete benchmark log. The longer the agent's responses are, "
+        "(Tokens) The number of tokens that comprise all agent's messages. The longer the agent's responses are, "
         "the larger this metric is. The negative of this value is the Conciseness."
     ),
     score=(
-        "(Points) Each test gives a different amount of score points. This score is the result of adding up the "
+        "(Points) Each test gives up to one point. This score is the result of adding up the "
         "number of score points achieved in all tests."
     ),
     ltm=(
@@ -67,7 +64,7 @@ METRIC_ALT = dict(
 METRIC_NAMES = {key: "LTM Score" if key == "ltm" else key.capitalize() for key in METRIC_ALT.keys()}
 METRIC_UNITS = dict(
     accuracy="%",
-    speed="tests per hour",
+    speed="tokens per second",
     cost="USD",
     verbosity="tokens",
     score="points",

--- a/utils/math.py
+++ b/utils/math.py
@@ -1,4 +1,4 @@
 def mean_std(values: list) -> tuple[float, float]:
     mean = sum(values) / len(values)
-    std = sum([(mean - v) ** 2 for v in values]) / len(values)
-    return mean, std ** 0.5
+    var = sum([(mean - v) ** 2 for v in values]) / len(values)
+    return mean, var ** 0.5

--- a/utils/math.py
+++ b/utils/math.py
@@ -1,0 +1,4 @@
+def mean_std(values: list) -> tuple[float, float]:
+    mean = sum(values) / len(values)
+    std = sum([(mean - v) ** 2 for v in values]) / len(values)
+    return mean, std ** 0.5


### PR DESCRIPTION
Results from multiple examples of the same test are aggregated and a standard deviation is computed from them. This deviation is shown in the overall score of the detailed report.

The speed metric has been changed from `tests per hour`, which is too configuration dependent, to `tokens per second`, which is generic and can be computed now that we record agent tokens and duration separately.

**NOTE:** Testing it with old results will fail due to the absence of `agent_tokens` in the global statistics file. 