### PR TITLE
Ltm 144 waits after reply

### DIFF
--- a/datasets/chapterbreak.py
+++ b/datasets/chapterbreak.py
@@ -150,7 +150,7 @@ class ChapterBreakDataset(DatasetInterface):
                 script=script,
                 expected_responses=[str(answer)],
                 is_question=is_question,
-                waits=[WaitCreator.create_wait(tokens=0) for _ in is_question],
+                waits=[WaitCreator.create_wait() for _ in is_question],  # This test is to happen uninterruptedly
             )
             example_list.append(example)
 

--- a/datasets/jokes.py
+++ b/datasets/jokes.py
@@ -42,11 +42,12 @@ class JokesDataset(DatasetInterface):
             jokes = deepcopy(JOKES)
             waits = []
 
-            filler_tokens = math.floor(self.memory_span * 0.75) // self.jokes_told
+            percentage_per_joke = 90 / self.jokes_told
             for joke_made in range(self.jokes_told):
                 if len(jokes) == 0:
                     logging.warning("Ran out of jokes")
                     break
+
                 # Select joke
                 joke = self.random.choice(jokes)
                 jokes.remove(joke)
@@ -55,8 +56,10 @@ class JokesDataset(DatasetInterface):
                 script.append(self.create_script_line(joke))
                 selected_jokes.append(joke)
                 is_question.append(False)
-                time_jump = create_time_jump(self.minutes_low, self.minutes_high)
-                waits.append(WaitCreator.create_wait(tokens=filler_tokens, time=time_jump))
+                waits.append(WaitCreator.create_wait(
+                    time=create_time_jump(self.minutes_low, self.minutes_high),
+                    percentage_finished=(joke_made + 1) * percentage_per_joke,
+                ))
 
             # Choose the joke we are going to look at
             answer = self.random.choice(selected_jokes)

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -134,6 +134,19 @@ class TestRunner:
         else:
             token_wait = action.tokens
 
+        # A nominal wait is 1 token, so skip this next step if that is what the token wait is.
+        if token_wait > 1:
+            # When waiting , we want to take the reply to the previous statement into account.
+            test_messages = self.master_log.messages(unique_id)
+            previous_reply = ""
+            for m in reversed(test_messages):
+                if m.startswith("Agent"):
+                    previous_reply = m.split(":")[-1]
+                    break
+
+            # Subtract the token wait from the previous reply.
+            token_wait = max(0, token_wait - self.agent.token_len(previous_reply))
+
         if log_this:
             self.master_log.add_wait_event(
                 unique_id,

--- a/runner/scheduler.py
+++ b/runner/scheduler.py
@@ -136,15 +136,12 @@ class TestRunner:
 
         # A nominal wait is 1 token, so skip this next step if that is what the token wait is.
         if token_wait > 1:
-            # When waiting , we want to take the reply to the previous statement into account.
-            test_messages = self.master_log.messages(unique_id)
-            previous_reply = ""
-            for m in reversed(test_messages):
-                if m.startswith("Agent"):
-                    previous_reply = m.split(":")[-1]
-                    break
+            # When waiting, we want to take the reply to the previous statement into account.
+            test_message_responses = list(self.master_log.test_events(unique_id, EventType.RESPONSE_MESSAGE))
+            # Last response is what we want
+            previous_reply = test_message_responses[-1].data["message"]
 
-            # Subtract the token wait from the previous reply.
+            # Subtract the number of tokens in the reply from the token wait
             token_wait = max(0, token_wait - self.agent.token_len(previous_reply))
 
         if log_this:


### PR DESCRIPTION
Claude tests seem to overrun because Claude is very verbose in its messages. One potential fix is in taking the reply to previous statement before the wait into account when calculating how long to wait for.  