### PR TITLE
New ltm score

### DIFF
--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -176,9 +176,7 @@ def normalize_and_aggregate_results(results: list[TestResult]) -> dict[str, dict
 
     for d in result_dict.values():
         norm_scores = [r.score / r.max_score for r in d["results"]]
-        ltm_scores = [s * r.tokens for s, r in zip(norm_scores, d["results"])]
         d["score"], d["std"] = mean_std(norm_scores)
-        d["ltm"], d["ltm_std"] = mean_std(ltm_scores)
 
     return result_dict
 
@@ -188,13 +186,13 @@ def get_summary_data(run_name: str, agent_name: str):
     assert len(results) > 0, f"No results were found for run {run_name} and agent {agent_name}."
     aggr_results = normalize_and_aggregate_results(results)
 
-    score = ltm_score = 0
-    score_std = ltm_score_std = 0
+    score = score_std = 0
     for dataset_name, dataset_results in aggr_results.items():
         score += dataset_results["score"]
         score_std += dataset_results["std"]
-        ltm_score += dataset_results["ltm"]
-        ltm_score_std += dataset_results["ltm_std"]
+
+    ltm_scores = [r.tokens for r in results if r.score == r.max_score]
+    ltm_score = sum(ltm_scores) / max(1, len(ltm_scores))
 
     return dict(
         speed=benchmark_data["agent_tokens"] / benchmark_data["duration"],
@@ -205,7 +203,6 @@ def get_summary_data(run_name: str, agent_name: str):
         score_std=score_std,
         accuracy=100 * score / len(aggr_results),
         ltm=ltm_score,
-        ltm_std=ltm_score_std,
     )
 
 

--- a/reporting/generate.py
+++ b/reporting/generate.py
@@ -2,6 +2,7 @@ import os
 import json
 import re
 import yaml
+import humanize
 from typing import List, Optional
 from random import Random
 from jinja2 import Environment, FileSystemLoader
@@ -12,7 +13,7 @@ from utils.constants import REPORT_TEMPLATES_DIR, GOODAI_RED, GOODAI_GREEN, METR
 from utils.data import load_b64
 from utils.math import mean_std
 from utils.ui import display_float_or_int
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -161,6 +162,7 @@ def generate_report(results: List[TestResult], output_name: Optional[str] = None
         achieved_score=display_float_or_int(metrics["score"]),
         max_score=display_float_or_int(metrics["max_score"]),
         score_std=display_float_or_int(metrics["score_std"]),
+        duration_str=humanize.precisedelta(timedelta(seconds=metrics["duration"])),
         **report_data,
     )
 
@@ -203,6 +205,7 @@ def get_summary_data(run_name: str, agent_name: str):
         score_std=score_std,
         accuracy=100 * score / len(aggr_results),
         ltm=ltm_score,
+        duration=benchmark_data["duration"],
     )
 
 

--- a/reporting/templates/detailed_report.html
+++ b/reporting/templates/detailed_report.html
@@ -95,12 +95,16 @@
         {% if overrun %}
             <p class="warning">WARNING. Memory span overrun by at least one test.</p>
         {% endif %}
-        <p><b>Agent</b>: {{ agent_name }}<br><b>Overall score</b>: {{ achieved_score }} <b>/</b> {{ max_score }} <b>±</b> {{ score_std }}</p>
+        <p>
+            <b>Agent</b>: {{ agent_name }}<br>
+            <b>Overall score</b>: {{ achieved_score }} <b>/</b> {{ max_score }} <b>±</b> {{ score_std }}
+        </p>
         <ul>
             {% for metric in global_metrics %}
                 <li title="{{ metric.alt }}"><b>{{ metric.name }}</b>: {{ metric.value }} {{ metric.units }}</li>
             {% endfor %}
         </ul>
+        <p>Finished in {{ duration_str }}</p>
     </div>
     <div class="run">
         <h1>{{ run_name }}</h1>

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ langchain-openai==0.0.2
 rouge_score==0.1.2
 litellm  # Unifies interface from most LLM APIs
 zstd==1.5.5.1  # To decompress chapterbreak
+humanize==4.9.0  # Shows data in human-readable form e.g. timedelta as "1 hour and 23 seconds"

--- a/runner/master_log.py
+++ b/runner/master_log.py
@@ -200,11 +200,11 @@ class MasterLog:
                     continue
             yield event
 
-    def as_context(self, test_id: str = ""):
+    def as_context(self, test_id: str = None) -> list[dict[str, str | datetime]]:
         context = []
 
         for event in self.log:
-            if test_id == "" or event.test_id == test_id:
+            if test_id is None or event.test_id == test_id:
                 if event.type in [EventType.SEND_MESSAGE, EventType.SEND_FILL]:
                     context.append({"role": "user", "content": event.data["message"], "timestamp": event.timestamp})
                 elif event.type in [EventType.RESPONSE_MESSAGE, EventType.RESPONSE_FILL]:


### PR DESCRIPTION
- Show run duration in detailed report
- Compute LTM score from aced tests

**DISCLAIMER**: I don't find this way of computing the LTM score satisfying. I am not even sure that we should compute an "LTM Score" at all. The name seems a bit misleading, although I have some proposals in that respect. See [this document](https://docs.google.com/document/d/15Sjo0EwEIWka1hysZwhnIA1nwCN3tTPVwHnnNsDzet8/edit?usp=sharing) for more details.

I was considering adding a method to the dataset interface, through which datasets could deliver an LTM score + confidence, when feasible:
```python
def get_ltm_score(self, ...) -> Tuple[float, float]:
    ltm_score = confidence = 0  # In range [0,1]
    return ltm_score, confidence
```

It's effectless by default, but specific datasets might provide a certain estimation (confidence close to 1) or vague estimations (lower confidences). We would then compute the overall LTM score as the weighted average of those scores, weighted by their confidence values.