### PR TITLE
Incorrect location score updated

### DIFF
--- a/data/tests/Benchmark 3 - 200k/results/LLMChatSession - claude-3-opus - 200000/Locations Directions/2_0.json
+++ b/data/tests/Benchmark 3 - 200k/results/LLMChatSession - claude-3-opus - 200000/Locations Directions/2_0.json
@@ -20,10 +20,12 @@
   "actual_responses": [
     "Based on the information you've provided about your hometown's layout, Kimberly, here's how you would travel from the Retail Area to the Playground, passing by the other points of interest:\n\n1. Start at the Retail Area, which is the central location in your hometown.\n\n2. Head north from the Retail Area until you reach the Hospital. The Hospital is located 2 kilometers north of the Retail Area.\n\n3. From the Hospital, head south for 1 kilometer until you reach the Library. The Library is situated 1 kilometer north of the Retail Area and 1 kilometer south of the Hospital.\n\n4. Continue heading south from the Library for another 1 kilometer until you reach the Park. The Park is located 1 kilometer south of the Retail Area and the Library.\n\n5. From the Park, head west for 1 kilometer until you arrive at the High Street. The High Street is situated 1 kilometer west of the Library.\n\n6. Finally, from the High Street, travel east for 1 kilometer to reach your destination, the Playground. The Playground is located 1 kilometer east of the High Street.\n\nSo, the complete route from the Retail Area to the Playground, passing by the other points of interest, would be:\n\nRetail Area \u2192 Hospital \u2192 Library \u2192 Park \u2192 High Street \u2192 Playground\n\nThis route covers a total distance of approximately 6 kilometers and allows you to visit all the mentioned locations in your hometown."
   ],
-  "auto_score": 0.0,
+  "score":0.0,
+  "auto_score": 1.0,
   "max_score": 1,
+  "reasoning": ["The agent's directions do not lead to the expected destination."],
   "auto_reasoning": [
-    "The agent's directions do not lead to the expected destination."
+    "The agent's directions lead to the expected destination."
   ],
   "tokens": 180052,
   "characters": 657005,

--- a/data/tests/Benchmark 3 - 200k/results/LLMChatSession - claude-3-opus - 200000/Locations Directions/2_0.json
+++ b/data/tests/Benchmark 3 - 200k/results/LLMChatSession - claude-3-opus - 200000/Locations Directions/2_0.json
@@ -20,10 +20,10 @@
   "actual_responses": [
     "Based on the information you've provided about your hometown's layout, Kimberly, here's how you would travel from the Retail Area to the Playground, passing by the other points of interest:\n\n1. Start at the Retail Area, which is the central location in your hometown.\n\n2. Head north from the Retail Area until you reach the Hospital. The Hospital is located 2 kilometers north of the Retail Area.\n\n3. From the Hospital, head south for 1 kilometer until you reach the Library. The Library is situated 1 kilometer north of the Retail Area and 1 kilometer south of the Hospital.\n\n4. Continue heading south from the Library for another 1 kilometer until you reach the Park. The Park is located 1 kilometer south of the Retail Area and the Library.\n\n5. From the Park, head west for 1 kilometer until you arrive at the High Street. The High Street is situated 1 kilometer west of the Library.\n\n6. Finally, from the High Street, travel east for 1 kilometer to reach your destination, the Playground. The Playground is located 1 kilometer east of the High Street.\n\nSo, the complete route from the Retail Area to the Playground, passing by the other points of interest, would be:\n\nRetail Area \u2192 Hospital \u2192 Library \u2192 Park \u2192 High Street \u2192 Playground\n\nThis route covers a total distance of approximately 6 kilometers and allows you to visit all the mentioned locations in your hometown."
   ],
-  "score": 1,
+  "auto_score": 0.0,
   "max_score": 1,
-  "reasoning": [
-    "Despite not following the expected order, the agent's directions lead to the expected destination."
+  "auto_reasoning": [
+    "The agent's directions do not lead to the expected destination."
   ],
   "tokens": 180052,
   "characters": 657005,


### PR DESCRIPTION
Correction added for a score in the benchmark - "data\reports\Detailed Report - Benchmark 3 - 200k - LLMChatSession - claude-3-opus - 200000.html", Locations Directions Test 3.

Renamed score -> auto_score, reasoning -> auto_reasoning