### PR TITLE
Litellm bug

### DIFF
--- a/ltm/agent.py
+++ b/ltm/agent.py
@@ -291,7 +291,7 @@ class LTMAgent:
 
     def _completion(self, context: List[dict[str, str]], temperature: float, label: str,
                     cost_callback: Callable[[float], Any]) -> str:
-
+        # TODO: max_tokens is borked: https://github.com/BerriAI/litellm/issues/4439
         response = completion(model=self.model, messages=context, timeout=self.config.timeout,
                               temperature=temperature)
         response_text = response['choices'][0]['message']['content']

--- a/ltm/agent.py
+++ b/ltm/agent.py
@@ -291,8 +291,9 @@ class LTMAgent:
 
     def _completion(self, context: List[dict[str, str]], temperature: float, label: str,
                     cost_callback: Callable[[float], Any]) -> str:
+
         response = completion(model=self.model, messages=context, timeout=self.config.timeout,
-                              temperature=temperature, max_tokens=self.max_completion_tokens)
+                              temperature=temperature)
         response_text = response['choices'][0]['message']['content']
         if self.prompt_callback:
             self.prompt_callback(self.session.session_id, label, context, response_text)


### PR DESCRIPTION
When our input is less than max_tokens, it sets the api max_tokens call to 4096 - input_size 

Here, our input prompt is 2906 tokens, max output is 4096, so the arguments for the API is 1190
And if our prompt is around 4090 tokens, then it asks the api t supply 6 tokens, which is obviously not enough
BUT
If our prompt is over 4096, litellm is like "lets just let the call fail" and passes 4096 to the API. But because the bug is on litellms side, the call doesnt fail
so it works correctly

